### PR TITLE
Add Python HTTP API with CRUD endpoints and OpenAPI spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # candidate-manager
-candidate manager
+
+Minimal API para gestionar candidatos, comentarios, evaluaciones y actividades usando el servidor HTTP incorporado de Python y SQLite.
+
+## Uso
+
+```bash
+python app.py
+```
+
+El servidor se ejecutará en `http://localhost:8000`.
+
+### Endpoints principales
+- `GET /candidates` – lista de candidatos
+- `POST /candidates` – crear candidato
+- `GET /candidates/{id}` – obtener candidato
+- `PUT /candidates/{id}` – actualizar candidato
+- `DELETE /candidates/{id}` – eliminar candidato
+
+Recursos análogos existen para `comments`, `evaluations` y `activities`.
+
+### Documentación
+La documentación OpenAPI está disponible en [`/swagger.json`](http://localhost:8000/swagger.json).

--- a/app.py
+++ b/app.py
@@ -1,0 +1,201 @@
+import json
+import re
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
+
+import db
+import services
+
+
+def parse_body(handler):
+    length = int(handler.headers.get('Content-Length', 0))
+    if length:
+        data = handler.rfile.read(length)
+        try:
+            return json.loads(data)
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def send_json(handler, data, status=200):
+    handler.send_response(status)
+    handler.send_header('Content-Type', 'application/json')
+    handler.end_headers()
+    handler.wfile.write(json.dumps(data).encode())
+
+
+class RequestHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/swagger.json':
+            try:
+                with open('swagger.json', 'r') as f:
+                    spec = json.load(f)
+                send_json(self, spec)
+            except FileNotFoundError:
+                send_json(self, {'error': 'Documentation not found'}, 404)
+            return
+
+        if self.path == '/candidates':
+            send_json(self, services.get_candidates())
+            return
+        m = re.fullmatch(r'/candidates/(\d+)', self.path)
+        if m:
+            cid = int(m.group(1))
+            cand = services.get_candidate(cid)
+            if cand:
+                send_json(self, cand)
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
+
+        if self.path == '/comments':
+            send_json(self, services.get_comments())
+            return
+        m = re.fullmatch(r'/comments/(\d+)', self.path)
+        if m:
+            cid = int(m.group(1))
+            com = services.get_comment(cid)
+            if com:
+                send_json(self, com)
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
+
+        if self.path == '/evaluations':
+            send_json(self, services.get_evaluations())
+            return
+        m = re.fullmatch(r'/evaluations/(\d+)', self.path)
+        if m:
+            eid = int(m.group(1))
+            ev = services.get_evaluation(eid)
+            if ev:
+                send_json(self, ev)
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
+
+        if self.path == '/activities':
+            send_json(self, services.get_activities())
+            return
+        m = re.fullmatch(r'/activities/(\d+)', self.path)
+        if m:
+            aid = int(m.group(1))
+            act = services.get_activity(aid)
+            if act:
+                send_json(self, act)
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
+
+        send_json(self, {'error': 'Unsupported endpoint'}, 404)
+
+    def do_POST(self):
+        data = parse_body(self)
+        if self.path == '/candidates':
+            cid = services.create_candidate(data)
+            send_json(self, {'id': cid}, 201)
+            return
+        if self.path == '/comments':
+            cid = services.create_comment(data)
+            send_json(self, {'id': cid}, 201)
+            return
+        if self.path == '/evaluations':
+            eid = services.create_evaluation(data)
+            send_json(self, {'id': eid}, 201)
+            return
+        if self.path == '/activities':
+            aid = services.create_activity(data)
+            send_json(self, {'id': aid}, 201)
+            return
+        send_json(self, {'error': 'Unsupported endpoint'}, 404)
+
+    def do_PUT(self):
+        data = parse_body(self)
+        m = re.fullmatch(r'/candidates/(\d+)', self.path)
+        if m:
+            cid = int(m.group(1))
+            ok = services.update_candidate(cid, data)
+            if ok:
+                send_json(self, {'status': 'updated'})
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
+        m = re.fullmatch(r'/comments/(\d+)', self.path)
+        if m:
+            cid = int(m.group(1))
+            ok = services.update_comment(cid, data)
+            if ok:
+                send_json(self, {'status': 'updated'})
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
+        m = re.fullmatch(r'/evaluations/(\d+)', self.path)
+        if m:
+            eid = int(m.group(1))
+            ok = services.update_evaluation(eid, data)
+            if ok:
+                send_json(self, {'status': 'updated'})
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
+        m = re.fullmatch(r'/activities/(\d+)', self.path)
+        if m:
+            aid = int(m.group(1))
+            ok = services.update_activity(aid, data)
+            if ok:
+                send_json(self, {'status': 'updated'})
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
+        send_json(self, {'error': 'Unsupported endpoint'}, 404)
+
+    def do_DELETE(self):
+        m = re.fullmatch(r'/candidates/(\d+)', self.path)
+        if m:
+            cid = int(m.group(1))
+            ok = services.delete_candidate(cid)
+            if ok:
+                send_json(self, {'status': 'deleted'})
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
+        m = re.fullmatch(r'/comments/(\d+)', self.path)
+        if m:
+            cid = int(m.group(1))
+            ok = services.delete_comment(cid)
+            if ok:
+                send_json(self, {'status': 'deleted'})
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
+        m = re.fullmatch(r'/evaluations/(\d+)', self.path)
+        if m:
+            eid = int(m.group(1))
+            ok = services.delete_evaluation(eid)
+            if ok:
+                send_json(self, {'status': 'deleted'})
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
+        m = re.fullmatch(r'/activities/(\d+)', self.path)
+        if m:
+            aid = int(m.group(1))
+            ok = services.delete_activity(aid)
+            if ok:
+                send_json(self, {'status': 'deleted'})
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
+        send_json(self, {'error': 'Unsupported endpoint'}, 404)
+
+
+def run():
+    db.init_db()
+    server = HTTPServer(('0.0.0.0', 8000), RequestHandler)
+    print('Serving on port 8000')
+    server.serve_forever()
+
+
+if __name__ == '__main__':
+    run()

--- a/db.py
+++ b/db.py
@@ -1,0 +1,55 @@
+import sqlite3
+
+DB_NAME = "candidates.db"
+
+def get_connection():
+    conn = sqlite3.connect(DB_NAME)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+def init_db():
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS candidates (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS comments (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            candidate_id INTEGER NOT NULL,
+            content TEXT NOT NULL,
+            FOREIGN KEY(candidate_id) REFERENCES candidates(id)
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS evaluations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            candidate_id INTEGER NOT NULL,
+            score INTEGER NOT NULL,
+            notes TEXT,
+            FOREIGN KEY(candidate_id) REFERENCES candidates(id)
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS activities (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            candidate_id INTEGER NOT NULL,
+            description TEXT NOT NULL,
+            activity_date TEXT NOT NULL,
+            FOREIGN KEY(candidate_id) REFERENCES candidates(id)
+        )
+        """
+    )
+    conn.commit()
+    conn.close()

--- a/services.py
+++ b/services.py
@@ -1,0 +1,206 @@
+import sqlite3
+from db import get_connection
+
+# Candidate Services
+
+def create_candidate(data):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO candidates(name, email) VALUES (?, ?)",
+        (data.get("name"), data.get("email")),
+    )
+    conn.commit()
+    cid = cur.lastrowid
+    conn.close()
+    return cid
+
+def get_candidates():
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM candidates")
+    rows = [dict(row) for row in cur.fetchall()]
+    conn.close()
+    return rows
+
+def get_candidate(cid):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM candidates WHERE id = ?", (cid,))
+    row = cur.fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+def update_candidate(cid, data):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE candidates SET name = ?, email = ? WHERE id = ?",
+        (data.get("name"), data.get("email"), cid),
+    )
+    conn.commit()
+    updated = cur.rowcount
+    conn.close()
+    return updated > 0
+
+def delete_candidate(cid):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM candidates WHERE id = ?", (cid,))
+    conn.commit()
+    deleted = cur.rowcount
+    conn.close()
+    return deleted > 0
+
+# Comment Services
+
+def create_comment(data):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO comments(candidate_id, content) VALUES (?, ?)",
+        (data.get("candidate_id"), data.get("content")),
+    )
+    conn.commit()
+    cid = cur.lastrowid
+    conn.close()
+    return cid
+
+def get_comments():
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM comments")
+    rows = [dict(row) for row in cur.fetchall()]
+    conn.close()
+    return rows
+
+def get_comment(cid):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM comments WHERE id = ?", (cid,))
+    row = cur.fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+def update_comment(cid, data):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE comments SET candidate_id = ?, content = ? WHERE id = ?",
+        (data.get("candidate_id"), data.get("content"), cid),
+    )
+    conn.commit()
+    updated = cur.rowcount
+    conn.close()
+    return updated > 0
+
+def delete_comment(cid):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM comments WHERE id = ?", (cid,))
+    conn.commit()
+    deleted = cur.rowcount
+    conn.close()
+    return deleted > 0
+
+# Evaluation Services
+
+def create_evaluation(data):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO evaluations(candidate_id, score, notes) VALUES (?, ?, ?)",
+        (data.get("candidate_id"), data.get("score"), data.get("notes")),
+    )
+    conn.commit()
+    eid = cur.lastrowid
+    conn.close()
+    return eid
+
+def get_evaluations():
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM evaluations")
+    rows = [dict(row) for row in cur.fetchall()]
+    conn.close()
+    return rows
+
+def get_evaluation(eid):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM evaluations WHERE id = ?", (eid,))
+    row = cur.fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+def update_evaluation(eid, data):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE evaluations SET candidate_id = ?, score = ?, notes = ? WHERE id = ?",
+        (data.get("candidate_id"), data.get("score"), data.get("notes"), eid),
+    )
+    conn.commit()
+    updated = cur.rowcount
+    conn.close()
+    return updated > 0
+
+def delete_evaluation(eid):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM evaluations WHERE id = ?", (eid,))
+    conn.commit()
+    deleted = cur.rowcount
+    conn.close()
+    return deleted > 0
+
+# Activity Services
+
+def create_activity(data):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO activities(candidate_id, description, activity_date) VALUES (?, ?, ?)",
+        (data.get("candidate_id"), data.get("description"), data.get("activity_date")),
+    )
+    conn.commit()
+    aid = cur.lastrowid
+    conn.close()
+    return aid
+
+def get_activities():
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM activities")
+    rows = [dict(row) for row in cur.fetchall()]
+    conn.close()
+    return rows
+
+def get_activity(aid):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM activities WHERE id = ?", (aid,))
+    row = cur.fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+def update_activity(aid, data):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE activities SET candidate_id = ?, description = ?, activity_date = ? WHERE id = ?",
+        (data.get("candidate_id"), data.get("description"), data.get("activity_date"), aid),
+    )
+    conn.commit()
+    updated = cur.rowcount
+    conn.close()
+    return updated > 0
+
+def delete_activity(aid):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM activities WHERE id = ?", (aid,))
+    conn.commit()
+    deleted = cur.rowcount
+    conn.close()
+    return deleted > 0

--- a/swagger.json
+++ b/swagger.json
@@ -1,0 +1,135 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Candidate Manager API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/candidates": {
+      "get": {
+        "summary": "List candidates",
+        "responses": {
+          "200": {"description": "OK"}
+        }
+      },
+      "post": {
+        "summary": "Create candidate",
+        "responses": {
+          "201": {"description": "Created"}
+        }
+      }
+    },
+    "/candidates/{id}": {
+      "get": {
+        "summary": "Get candidate",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {"type": "integer"}
+          }
+        ],
+        "responses": {
+          "200": {"description": "OK"},
+          "404": {"description": "Not found"}
+        }
+      },
+      "put": {
+        "summary": "Update candidate",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {"type": "integer"}
+          }
+        ],
+        "responses": {
+          "200": {"description": "Updated"},
+          "404": {"description": "Not found"}
+        }
+      },
+      "delete": {
+        "summary": "Delete candidate",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {"type": "integer"}
+          }
+        ],
+        "responses": {
+          "200": {"description": "Deleted"},
+          "404": {"description": "Not found"}
+        }
+      }
+    },
+    "/comments": {
+      "get": {"summary": "List comments", "responses": {"200": {"description": "OK"}}},
+      "post": {"summary": "Create comment", "responses": {"201": {"description": "Created"}}}
+    },
+    "/comments/{id}": {
+      "get": {"summary": "Get comment", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "OK"}, "404": {"description": "Not found"}}},
+      "put": {"summary": "Update comment", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Updated"}, "404": {"description": "Not found"}}},
+      "delete": {"summary": "Delete comment", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Deleted"}, "404": {"description": "Not found"}}}
+    },
+    "/evaluations": {
+      "get": {"summary": "List evaluations", "responses": {"200": {"description": "OK"}}},
+      "post": {"summary": "Create evaluation", "responses": {"201": {"description": "Created"}}}
+    },
+    "/evaluations/{id}": {
+      "get": {"summary": "Get evaluation", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "OK"}, "404": {"description": "Not found"}}},
+      "put": {"summary": "Update evaluation", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Updated"}, "404": {"description": "Not found"}}},
+      "delete": {"summary": "Delete evaluation", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Deleted"}, "404": {"description": "Not found"}}}
+    },
+    "/activities": {
+      "get": {"summary": "List activities", "responses": {"200": {"description": "OK"}}},
+      "post": {"summary": "Create activity", "responses": {"201": {"description": "Created"}}}
+    },
+    "/activities/{id}": {
+      "get": {"summary": "Get activity", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "OK"}, "404": {"description": "Not found"}}},
+      "put": {"summary": "Update activity", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Updated"}, "404": {"description": "Not found"}}},
+      "delete": {"summary": "Delete activity", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Deleted"}, "404": {"description": "Not found"}}}
+    }
+  },
+  "components": {
+    "schemas": {
+      "Candidate": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "integer"},
+          "name": {"type": "string"},
+          "email": {"type": "string"}
+        }
+      },
+      "Comment": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "integer"},
+          "candidate_id": {"type": "integer"},
+          "content": {"type": "string"}
+        }
+      },
+      "Evaluation": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "integer"},
+          "candidate_id": {"type": "integer"},
+          "score": {"type": "integer"},
+          "notes": {"type": "string"}
+        }
+      },
+      "Activity": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "integer"},
+          "candidate_id": {"type": "integer"},
+          "description": {"type": "string"},
+          "activity_date": {"type": "string"}
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement Python HTTP server managing candidates, comments, evaluations and activities
- add SQLite-backed services for each entity
- document API via OpenAPI spec served at `/swagger.json`

## Testing
- `python -m py_compile app.py db.py services.py`


------
https://chatgpt.com/codex/tasks/task_e_6893523037e4832fbe8370b9e4d8cbe5