### PR TITLE
Add migration system and new database tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+candidates.db
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # candidate-manager
 
-Minimal API para gestionar candidatos, comentarios, evaluaciones y actividades usando el servidor HTTP incorporado de Python y SQLite.
+Minimal API para gestionar candidatos, comentarios, usuarios, archivos, evaluaciones y un historial de actividad usando el servidor HTTP incorporado de Python y SQLite.
 
 ## Uso
 
+Antes de iniciar el servidor es necesario aplicar las migraciones de base de datos.
+
 ```bash
+python migrate.py
 python app.py
 ```
 
@@ -17,7 +20,7 @@ El servidor se ejecutará en `http://localhost:8000`.
 - `PUT /candidates/{id}` – actualizar candidato
 - `DELETE /candidates/{id}` – eliminar candidato
 
-Recursos análogos existen para `comments`, `evaluations` y `activities`.
+Recursos análogos existen para `comments`, `evaluations` y `activities`. Además se han añadido tablas `users` y `files` disponibles mediante los servicios internos.
 
 ### Documentación
 La documentación OpenAPI está disponible en [`/swagger.json`](http://localhost:8000/swagger.json).

--- a/db.py
+++ b/db.py
@@ -1,55 +1,17 @@
+import os
 import sqlite3
 
-DB_NAME = "candidates.db"
+DB_NAME = os.getenv("DB_NAME", "candidates.db")
+
 
 def get_connection():
     conn = sqlite3.connect(DB_NAME)
     conn.row_factory = sqlite3.Row
     return conn
 
+
 def init_db():
-    conn = get_connection()
-    cur = conn.cursor()
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS candidates (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            name TEXT NOT NULL,
-            email TEXT NOT NULL
-        )
-        """
-    )
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS comments (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            candidate_id INTEGER NOT NULL,
-            content TEXT NOT NULL,
-            FOREIGN KEY(candidate_id) REFERENCES candidates(id)
-        )
-        """
-    )
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS evaluations (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            candidate_id INTEGER NOT NULL,
-            score INTEGER NOT NULL,
-            notes TEXT,
-            FOREIGN KEY(candidate_id) REFERENCES candidates(id)
-        )
-        """
-    )
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS activities (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            candidate_id INTEGER NOT NULL,
-            description TEXT NOT NULL,
-            activity_date TEXT NOT NULL,
-            FOREIGN KEY(candidate_id) REFERENCES candidates(id)
-        )
-        """
-    )
-    conn.commit()
-    conn.close()
+    """Apply pending database migrations."""
+    from migrate import migrate
+
+    migrate(DB_NAME)

--- a/migrate.py
+++ b/migrate.py
@@ -1,0 +1,41 @@
+import os
+import sqlite3
+
+MIGRATIONS_DIR = os.path.join(os.path.dirname(__file__), "migrations")
+
+
+def migrate(db_name=None):
+    """Apply pending SQL migrations in order."""
+    if db_name is None:
+        db_name = os.getenv("DB_NAME", "candidates.db")
+    conn = sqlite3.connect(db_name)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS schema_migrations (version TEXT PRIMARY KEY)"
+    )
+    applied = {
+        row[0] for row in cur.execute("SELECT version FROM schema_migrations")
+    }
+    migrations = [
+        f
+        for f in sorted(os.listdir(MIGRATIONS_DIR))
+        if f.endswith(".sql")
+    ]
+    for fname in migrations:
+        version = fname.split("_")[0]
+        if version in applied:
+            continue
+        path = os.path.join(MIGRATIONS_DIR, fname)
+        with open(path, "r", encoding="utf-8") as f:
+            sql = f.read()
+        cur.executescript(sql)
+        cur.execute(
+            "INSERT INTO schema_migrations(version) VALUES (?)", (version,)
+        )
+        print(f"Applied migration {fname}")
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":
+    migrate()

--- a/migrations/001_create_tables.sql
+++ b/migrations/001_create_tables.sql
@@ -1,0 +1,44 @@
+-- Initial schema
+CREATE TABLE IF NOT EXISTS candidates (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS comments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    candidate_id INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    FOREIGN KEY(candidate_id) REFERENCES candidates(id)
+);
+
+CREATE TABLE IF NOT EXISTS evaluations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    candidate_id INTEGER NOT NULL,
+    score INTEGER NOT NULL,
+    notes TEXT,
+    FOREIGN KEY(candidate_id) REFERENCES candidates(id)
+);
+
+CREATE TABLE IF NOT EXISTS activity_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    candidate_id INTEGER NOT NULL,
+    description TEXT NOT NULL,
+    activity_date TEXT NOT NULL,
+    FOREIGN KEY(candidate_id) REFERENCES candidates(id)
+);
+
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT NOT NULL UNIQUE,
+    email TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS files (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    candidate_id INTEGER NOT NULL,
+    filename TEXT NOT NULL,
+    path TEXT NOT NULL,
+    uploaded_at TEXT NOT NULL,
+    FOREIGN KEY(candidate_id) REFERENCES candidates(id)
+);

--- a/services.py
+++ b/services.py
@@ -1,4 +1,3 @@
-import sqlite3
 from db import get_connection
 
 # Candidate Services
@@ -160,7 +159,7 @@ def create_activity(data):
     conn = get_connection()
     cur = conn.cursor()
     cur.execute(
-        "INSERT INTO activities(candidate_id, description, activity_date) VALUES (?, ?, ?)",
+        "INSERT INTO activity_history(candidate_id, description, activity_date) VALUES (?, ?, ?)",
         (data.get("candidate_id"), data.get("description"), data.get("activity_date")),
     )
     conn.commit()
@@ -168,27 +167,30 @@ def create_activity(data):
     conn.close()
     return aid
 
+
 def get_activities():
     conn = get_connection()
     cur = conn.cursor()
-    cur.execute("SELECT * FROM activities")
+    cur.execute("SELECT * FROM activity_history")
     rows = [dict(row) for row in cur.fetchall()]
     conn.close()
     return rows
 
+
 def get_activity(aid):
     conn = get_connection()
     cur = conn.cursor()
-    cur.execute("SELECT * FROM activities WHERE id = ?", (aid,))
+    cur.execute("SELECT * FROM activity_history WHERE id = ?", (aid,))
     row = cur.fetchone()
     conn.close()
     return dict(row) if row else None
+
 
 def update_activity(aid, data):
     conn = get_connection()
     cur = conn.cursor()
     cur.execute(
-        "UPDATE activities SET candidate_id = ?, description = ?, activity_date = ? WHERE id = ?",
+        "UPDATE activity_history SET candidate_id = ?, description = ?, activity_date = ? WHERE id = ?",
         (data.get("candidate_id"), data.get("description"), data.get("activity_date"), aid),
     )
     conn.commit()
@@ -196,10 +198,136 @@ def update_activity(aid, data):
     conn.close()
     return updated > 0
 
+
 def delete_activity(aid):
     conn = get_connection()
     cur = conn.cursor()
-    cur.execute("DELETE FROM activities WHERE id = ?", (aid,))
+    cur.execute("DELETE FROM activity_history WHERE id = ?", (aid,))
+    conn.commit()
+    deleted = cur.rowcount
+    conn.close()
+    return deleted > 0
+
+
+# User Services
+
+
+def create_user(data):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO users(username, email) VALUES (?, ?)",
+        (data.get("username"), data.get("email")),
+    )
+    conn.commit()
+    uid = cur.lastrowid
+    conn.close()
+    return uid
+
+
+def get_users():
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM users")
+    rows = [dict(row) for row in cur.fetchall()]
+    conn.close()
+    return rows
+
+
+def get_user(uid):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM users WHERE id = ?", (uid,))
+    row = cur.fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def update_user(uid, data):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE users SET username = ?, email = ? WHERE id = ?",
+        (data.get("username"), data.get("email"), uid),
+    )
+    conn.commit()
+    updated = cur.rowcount
+    conn.close()
+    return updated > 0
+
+
+def delete_user(uid):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM users WHERE id = ?", (uid,))
+    conn.commit()
+    deleted = cur.rowcount
+    conn.close()
+    return deleted > 0
+
+
+# File Services
+
+
+def create_file(data):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO files(candidate_id, filename, path, uploaded_at) VALUES (?, ?, ?, ?)",
+        (
+            data.get("candidate_id"),
+            data.get("filename"),
+            data.get("path"),
+            data.get("uploaded_at"),
+        ),
+    )
+    conn.commit()
+    fid = cur.lastrowid
+    conn.close()
+    return fid
+
+
+def get_files():
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM files")
+    rows = [dict(row) for row in cur.fetchall()]
+    conn.close()
+    return rows
+
+
+def get_file(fid):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM files WHERE id = ?", (fid,))
+    row = cur.fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def update_file(fid, data):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE files SET candidate_id = ?, filename = ?, path = ?, uploaded_at = ? WHERE id = ?",
+        (
+            data.get("candidate_id"),
+            data.get("filename"),
+            data.get("path"),
+            data.get("uploaded_at"),
+            fid,
+        ),
+    )
+    conn.commit()
+    updated = cur.rowcount
+    conn.close()
+    return updated > 0
+
+
+def delete_file(fid):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM files WHERE id = ?", (fid,))
     conn.commit()
     deleted = cur.rowcount
     conn.close()


### PR DESCRIPTION
## Summary
- add simple SQL migration runner and base schema migration
- switch database initialization to run migrations
- expand services with activity history, users, and file helpers

## Testing
- `python migrate.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689354c3b14c832fbc4054d7e2d2969b