### PR TITLE
Add JWT-based user authentication with MFA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+data.db

--- a/db.js
+++ b/db.js
@@ -1,0 +1,12 @@
+const Database = require('better-sqlite3');
+const db = new Database('data.db');
+
+db.exec(`CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT UNIQUE NOT NULL,
+  password TEXT NOT NULL,
+  twofa_secret TEXT,
+  refresh_token TEXT
+)`);
+
+module.exports = db;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "candidate-manager",
+  "version": "1.0.0",
+  "description": "candidate manager",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "better-sqlite3": "^9.4.3",
+    "cookie-parser": "^1.4.6",
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2",
+    "speakeasy": "^2.0.0"
+  },
+  "devDependencies": {
+    "supertest": "^6.3.3"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,113 @@
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const cookieParser = require('cookie-parser');
+const speakeasy = require('speakeasy');
+const db = require('./db');
+
+const app = express();
+app.use(express.json());
+app.use(cookieParser());
+
+const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+const JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET || 'refresh_secret';
+const ACCESS_TOKEN_EXPIRES = '15m';
+const REFRESH_TOKEN_EXPIRES = '7d';
+
+function generateAccessToken(user) {
+  return jwt.sign({ id: user.id, username: user.username }, JWT_SECRET, { expiresIn: ACCESS_TOKEN_EXPIRES });
+}
+
+function generateRefreshToken(user) {
+  return jwt.sign({ id: user.id }, JWT_REFRESH_SECRET, { expiresIn: REFRESH_TOKEN_EXPIRES });
+}
+
+function authMiddleware(req, res, next) {
+  const header = req.headers['authorization'];
+  if (!header) return res.sendStatus(401);
+  const token = header.split(' ')[1];
+  jwt.verify(token, JWT_SECRET, (err, user) => {
+    if (err) return res.sendStatus(403);
+    req.user = user;
+    next();
+  });
+}
+
+app.post('/register', async (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) return res.status(400).json({ error: 'missing fields' });
+  const hashed = await bcrypt.hash(password, 10);
+  try {
+    db.prepare('INSERT INTO users (username, password) VALUES (?, ?)').run(username, hashed);
+    res.sendStatus(201);
+  } catch (e) {
+    if (e.code === 'SQLITE_CONSTRAINT_UNIQUE') return res.status(409).json({ error: 'user exists' });
+    res.status(500).json({ error: 'db error' });
+  }
+});
+
+app.post('/login', async (req, res) => {
+  const { username, password, token } = req.body;
+  const user = db.prepare('SELECT * FROM users WHERE username=?').get(username);
+  if (!user) return res.status(401).json({ error: 'invalid credentials' });
+  const match = await bcrypt.compare(password, user.password);
+  if (!match) return res.status(401).json({ error: 'invalid credentials' });
+  if (user.twofa_secret) {
+    const verified = speakeasy.totp.verify({ secret: user.twofa_secret, encoding: 'base32', token });
+    if (!verified) return res.status(401).json({ error: 'invalid 2fa token' });
+  }
+  const accessToken = generateAccessToken(user);
+  const refreshToken = generateRefreshToken(user);
+  const rtHash = await bcrypt.hash(refreshToken, 10);
+  db.prepare('UPDATE users SET refresh_token=? WHERE id=?').run(rtHash, user.id);
+  res.cookie('refreshToken', refreshToken, { httpOnly: true, secure: true, sameSite: 'strict' });
+  res.json({ accessToken });
+});
+
+app.post('/refresh', async (req, res) => {
+  const token = req.cookies.refreshToken;
+  if (!token) return res.sendStatus(401);
+  try {
+    const payload = jwt.verify(token, JWT_REFRESH_SECRET);
+    const user = db.prepare('SELECT * FROM users WHERE id=?').get(payload.id);
+    if (!user || !user.refresh_token) return res.sendStatus(403);
+    const valid = await bcrypt.compare(token, user.refresh_token);
+    if (!valid) return res.sendStatus(403);
+    const accessToken = generateAccessToken(user);
+    res.json({ accessToken });
+  } catch (e) {
+    res.sendStatus(403);
+  }
+});
+
+app.post('/logout', (req, res) => {
+  const token = req.cookies.refreshToken;
+  if (token) {
+    try {
+      const payload = jwt.verify(token, JWT_REFRESH_SECRET);
+      db.prepare('UPDATE users SET refresh_token=NULL WHERE id=?').run(payload.id);
+    } catch (e) {}
+  }
+  res.clearCookie('refreshToken', { httpOnly: true, secure: true, sameSite: 'strict' });
+  res.sendStatus(204);
+});
+
+app.post('/2fa/setup', authMiddleware, (req, res) => {
+  const secret = speakeasy.generateSecret();
+  res.json({ secret: secret.base32 });
+});
+
+app.post('/2fa/verify', authMiddleware, (req, res) => {
+  const { secret, token } = req.body;
+  const verified = speakeasy.totp.verify({ secret, encoding: 'base32', token });
+  if (!verified) return res.status(400).json({ error: 'invalid token' });
+  db.prepare('UPDATE users SET twofa_secret=? WHERE id=?').run(secret, req.user.id);
+  res.sendStatus(200);
+});
+
+if (require.main === module) {
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => console.log(`Server running on ${PORT}`));
+}
+
+module.exports = app;

--- a/test.js
+++ b/test.js
@@ -1,0 +1,17 @@
+const request = require('supertest');
+const app = require('./server');
+
+async function run() {
+  try {
+    await request(app).post('/register').send({ username: 'alice', password: 'password' }).expect(201);
+    const loginRes = await request(app).post('/login').send({ username: 'alice', password: 'password' }).expect(200);
+    const cookie = loginRes.headers['set-cookie'];
+    await request(app).post('/refresh').set('Cookie', cookie).expect(200);
+    console.log('basic auth flow passed');
+  } catch (err) {
+    console.error('tests failed', err);
+    process.exit(1);
+  }
+}
+
+run();


### PR DESCRIPTION
## Summary
- add Express server with SQLite-backed user table
- implement registration, login, JWT refresh/logout, and TOTP-based 2FA
- include basic integration test script

## Testing
- `npm test` *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_689352461cb8832fa17cb3862b907bd2