### PR TITLE
Add privacy compliance features and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # candidate-manager
-candidate manager
+
+Aplicación de ejemplo para gestionar candidatos de manera segura.
+
+## Documentación
+
+- [Política de Privacidad](docs/PRIVACY_POLICY.md)
+- [Términos de Uso](docs/TERMS_OF_USE.md)
+
+## Características
+
+- Consentimiento explícito antes de almacenar información personal.
+- Mecanismos de anonimización, derecho al olvido y retención limitada.
+- Cifrado simple de datos tanto en tránsito como en reposo.

--- a/candidate_manager/__init__.py
+++ b/candidate_manager/__init__.py
@@ -1,0 +1,6 @@
+"""Candidate Manager package.
+
+Provides basic storage with privacy compliance features.
+"""
+
+from .store import CandidateStore  # noqa: F401

--- a/candidate_manager/store.py
+++ b/candidate_manager/store.py
@@ -1,0 +1,122 @@
+"""Storage module with privacy features.
+
+This module provides a :class:`CandidateStore` that handles candidate data
+with explicit consent checks, anonymization, right to be forgotten, limited
+retention and simple XOR based encryption for data at rest and in transit.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+import json
+import os
+import time
+import base64
+from typing import Dict, Optional
+
+
+@dataclass
+class Candidate:
+    """Representation of a candidate."""
+    candidate_id: str
+    name: Optional[str]
+    email: Optional[str]
+    cv: Optional[str]
+    consent: bool
+    created_at: float | None = None
+    anonymized: bool = False
+
+
+class ConsentRequiredError(Exception):
+    """Raised when trying to store candidate data without consent."""
+
+
+def _xor_bytes(data: bytes, key: bytes) -> bytes:
+    """Return XOR of ``data`` with ``key`` repeated as needed."""
+    return bytes(b ^ key[i % len(key)] for i, b in enumerate(data))
+
+
+def encrypt(plaintext: bytes, key: bytes) -> bytes:
+    """Encrypt ``plaintext`` using XOR and return base64 encoded bytes."""
+    return base64.b64encode(_xor_bytes(plaintext, key))
+
+
+def decrypt(ciphertext: bytes, key: bytes) -> bytes:
+    """Decrypt base64 encoded ``ciphertext`` produced by :func:`encrypt`."""
+    raw = base64.b64decode(ciphertext)
+    return _xor_bytes(raw, key)
+
+
+class CandidateStore:
+    """Store candidate information with privacy features."""
+
+    def __init__(self, file_path: str, key: bytes):
+        self.file_path = file_path
+        self.key = key
+        self._data: Dict[str, Candidate] = {}
+        if os.path.exists(self.file_path):
+            self._load()
+
+    def _load(self) -> None:
+        with open(self.file_path, "rb") as fh:
+            plaintext = decrypt(fh.read(), self.key)
+        raw = json.loads(plaintext.decode())
+        self._data = {cid: Candidate(**c) for cid, c in raw.items()}
+
+    def _save(self) -> None:
+        raw = {cid: asdict(c) for cid, c in self._data.items()}
+        plaintext = json.dumps(raw).encode()
+        ciphertext = encrypt(plaintext, self.key)
+        with open(self.file_path, "wb") as fh:
+            fh.write(ciphertext)
+
+    def add(self, candidate: Candidate) -> None:
+        """Add a candidate after verifying consent."""
+        if not candidate.consent:
+            raise ConsentRequiredError("Explicit consent required")
+        candidate.created_at = time.time()
+        self._data[candidate.candidate_id] = candidate
+        self._save()
+
+    def get(self, candidate_id: str) -> Optional[Candidate]:
+        return self._data.get(candidate_id)
+
+    def anonymize(self, candidate_id: str) -> None:
+        cand = self._data.get(candidate_id)
+        if not cand:
+            return
+        cand.name = None
+        cand.email = None
+        cand.cv = None
+        cand.anonymized = True
+        self._save()
+
+    def delete(self, candidate_id: str) -> None:
+        if candidate_id in self._data:
+            del self._data[candidate_id]
+            self._save()
+
+    def purge_expired(self, retention_days: int) -> None:
+        """Remove candidates older than ``retention_days`` days."""
+        cutoff = time.time() - retention_days * 86400
+        to_delete = [cid for cid, c in self._data.items() if c.created_at and c.created_at < cutoff]
+        for cid in to_delete:
+            del self._data[cid]
+        if to_delete:
+            self._save()
+
+    def export_encrypted(self, candidate_id: str) -> Optional[bytes]:
+        """Return encrypted payload for secure transit."""
+        cand = self._data.get(candidate_id)
+        if not cand:
+            return None
+        payload = json.dumps(asdict(cand)).encode()
+        return encrypt(payload, self.key)
+
+    def import_encrypted(self, data: bytes) -> Candidate:
+        """Import candidate data from an encrypted payload."""
+        payload = decrypt(data, self.key)
+        cdict = json.loads(payload.decode())
+        candidate = Candidate(**cdict)
+        self._data[candidate.candidate_id] = candidate
+        self._save()
+        return candidate

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -1,0 +1,14 @@
+# Política de Privacidad
+
+Esta aplicación almacena datos personales de candidatos para fines de
+reclutamiento. Para cumplir con las regulaciones de protección de datos:
+
+- Se requiere consentimiento explícito antes de guardar cualquier
+  información personal o CV.
+- Los datos se cifran tanto en tránsito como en reposo utilizando una clave
+  simétrica.
+- Los candidatos pueden solicitar la anonimización o eliminación de sus
+datos ("derecho al olvido").
+- La información se conserva únicamente durante el periodo necesario para el
+proceso de selección y se elimina automáticamente después del plazo de
+retención establecido.

--- a/docs/TERMS_OF_USE.md
+++ b/docs/TERMS_OF_USE.md
@@ -1,0 +1,11 @@
+# Términos de Uso
+
+Al utilizar este software aceptas lo siguiente:
+
+1. Proporcionarás únicamente información veraz y actualizada.
+2. Debes contar con autorización para compartir cualquier dato o CV
+   proporcionado.
+3. Podrás retirar tu consentimiento en cualquier momento solicitando la
+   eliminación o anonimización de tus datos.
+4. El equipo desarrollador se reserva el derecho de modificar estos términos
+   según sea necesario para cumplir con cambios regulatorios.

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,77 @@
+import os
+import json
+from candidate_manager.store import CandidateStore, Candidate, ConsentRequiredError, decrypt
+
+
+def make_store(tmp_path):
+    key = b"supersecret"
+    file_path = tmp_path / "data.enc"
+    return CandidateStore(str(file_path), key)
+
+
+def test_add_with_consent(tmp_path):
+    store = make_store(tmp_path)
+    cand = Candidate("1", "Ana", "ana@example.com", "cv", True)
+    store.add(cand)
+    assert store.get("1").name == "Ana"
+
+
+def test_add_without_consent(tmp_path):
+    store = make_store(tmp_path)
+    cand = Candidate("1", "Ana", "ana@example.com", "cv", False)
+    try:
+        store.add(cand)
+    except ConsentRequiredError:
+        pass
+    else:
+        assert False, "ConsentRequiredError not raised"
+
+
+def test_anonymize(tmp_path):
+    store = make_store(tmp_path)
+    cand = Candidate("1", "Ana", "ana@example.com", "cv", True)
+    store.add(cand)
+    store.anonymize("1")
+    res = store.get("1")
+    assert res.name is None and res.anonymized
+
+
+def test_delete_and_purge(tmp_path):
+    store = make_store(tmp_path)
+    cand = Candidate("1", "Ana", "ana@example.com", "cv", True)
+    store.add(cand)
+    store.delete("1")
+    assert store.get("1") is None
+
+    # re-add and simulate old timestamp for purge
+    store.add(cand)
+    store._data["1"].created_at = 1
+    store._save()
+    store.purge_expired(retention_days=1)
+    assert store.get("1") is None
+
+
+def test_file_is_encrypted(tmp_path):
+    key = b"supersecret"
+    file_path = tmp_path / "data.enc"
+    store = CandidateStore(str(file_path), key)
+    cand = Candidate("1", "Ana", "ana@example.com", "cv", True)
+    store.add(cand)
+    with open(file_path, "rb") as fh:
+        raw = fh.read()
+    assert b"Ana" not in raw
+    # ensure decrypting retrieves data
+    assert b"Ana" in decrypt(raw, key)
+
+
+def test_export_import(tmp_path):
+    store = make_store(tmp_path)
+    cand = Candidate("1", "Ana", "ana@example.com", "cv", True)
+    store.add(cand)
+    payload = store.export_encrypted("1")
+    # payload should not contain plaintext name
+    assert b"Ana" not in payload
+    # import into new store
+    new_store = make_store(tmp_path)
+    new_store.import_encrypted(payload)
+    assert new_store.get("1").name == "Ana"


### PR DESCRIPTION
## Summary
- Add privacy policy and terms of use documentation
- Implement candidate storage with consent checks, anonymization and simple encryption
- Provide tests covering consent, anonymization, deletion, export/import and retention

## Testing
- `python -m pytest tests/test_store.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_6893525d21dc832fa63f83789bce9e13