### PR TITLE
Add minimal full-stack candidate manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# candidate-manager
-candidate manager
+# Candidate Manager
+
+Simple full-stack application with a Node.js backend and basic frontend for managing candidates. The server exposes a small REST API and serves the static frontend.
+
+## Running
+
+```bash
+npm start
+```
+
+Then open `http://localhost:3000` in your browser.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "candidate-manager",
+  "version": "1.0.0",
+  "description": "candidate manager",
+  "main": "index.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,27 @@
+async function fetchCandidates() {
+  const res = await fetch('/api/candidates');
+  const candidates = await res.json();
+  const list = document.getElementById('candidate-list');
+  list.innerHTML = '';
+  candidates.forEach(c => {
+    const li = document.createElement('li');
+    li.textContent = `${c.name} (${c.email})`;
+    list.appendChild(li);
+  });
+}
+
+document.getElementById('candidate-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const name = document.getElementById('name').value;
+  const email = document.getElementById('email').value;
+  await fetch('/api/candidates', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, email })
+  });
+  document.getElementById('name').value = '';
+  document.getElementById('email').value = '';
+  fetchCandidates();
+});
+
+fetchCandidates();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Candidate Manager</title>
+</head>
+<body>
+  <h1>Candidate Manager</h1>
+  <form id="candidate-form">
+    <input type="text" id="name" placeholder="Name" required />
+    <input type="email" id="email" placeholder="Email" required />
+    <button type="submit">Add Candidate</button>
+  </form>
+  <ul id="candidate-list"></ul>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,67 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+let candidates = [];
+let nextId = 1;
+
+function serveStaticFile(req, res) {
+  let filePath = req.url === '/' ? '/index.html' : req.url;
+  filePath = path.join(__dirname, 'public', filePath);
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+    } else {
+      const ext = path.extname(filePath).toLowerCase();
+      const mime = {
+        '.html': 'text/html',
+        '.js': 'application/javascript',
+        '.css': 'text/css',
+        '.json': 'application/json'
+      }[ext] || 'text/plain';
+      res.writeHead(200, { 'Content-Type': mime });
+      res.end(content);
+    }
+  });
+}
+
+function handleApi(req, res) {
+  if (req.method === 'GET' && req.url === '/api/candidates') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(candidates));
+  } else if (req.method === 'POST' && req.url === '/api/candidates') {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      try {
+        const data = JSON.parse(body);
+        const candidate = { id: nextId++, name: data.name, email: data.email };
+        candidates.push(candidate);
+        res.writeHead(201, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(candidate));
+      } catch (e) {
+        res.writeHead(400);
+        res.end('Invalid JSON');
+      }
+    });
+  } else {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+}
+
+const server = http.createServer((req, res) => {
+  if (req.url.startsWith('/api/')) {
+    handleApi(req, res);
+  } else {
+    serveStaticFile(req, res);
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Node.js server with in-memory candidate API and static file serving
- create simple frontend to list and add candidates
- document run instructions

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.js` *(Server listening on port 3000)*

------
https://chatgpt.com/codex/tasks/task_e_68934b4cb8a4832fbc8b6ffb4c70ad22