### PR TITLE
Implement role-based permissions with tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "candidate-manager",
+  "version": "1.0.0",
+  "description": "candidate manager",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/src/authorize.js
+++ b/src/authorize.js
@@ -1,0 +1,15 @@
+const { roles } = require('./roles');
+
+function authorize(action, handler) {
+  return (req, res) => {
+    const role = req.headers['x-role'];
+    const permissions = roles[role] || [];
+    if (permissions.includes(action)) {
+      return handler(req, res);
+    }
+    res.statusCode = 403;
+    res.end('Forbidden');
+  };
+}
+
+module.exports = { authorize };

--- a/src/roles.js
+++ b/src/roles.js
@@ -1,0 +1,7 @@
+const roles = {
+  admin: ['read', 'create', 'update', 'delete'],
+  manager: ['read', 'update'],
+  recruiter: ['read']
+};
+
+module.exports = { roles };

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,29 @@
+const http = require('http');
+const { authorize } = require('./authorize');
+
+const candidates = [{ id: 1, name: 'Alice' }];
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/candidates' && req.method === 'GET') {
+    authorize('read', (req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify(candidates));
+    })(req, res);
+  } else if (req.url === '/candidates' && req.method === 'POST') {
+    authorize('create', (req, res) => {
+      candidates.push({ id: candidates.length + 1, name: 'New' });
+      res.statusCode = 201;
+      res.end('created');
+    })(req, res);
+  } else {
+    res.statusCode = 404;
+    res.end('Not Found');
+  }
+});
+
+module.exports = { server };
+
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  server.listen(port, () => console.log(`Server running on ${port}`));
+}

--- a/test/authorize.test.js
+++ b/test/authorize.test.js
@@ -1,0 +1,29 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { authorize } = require('../src/authorize');
+
+function makeRes() {
+  return {
+    statusCode: 200,
+    ended: false,
+    end() { this.ended = true; },
+    setHeader() {}
+  };
+}
+
+test('authorize allows action when role has permission', () => {
+  const req = { headers: { 'x-role': 'admin' } };
+  const res = makeRes();
+  let called = false;
+  authorize('create', () => { called = true; })(req, res);
+  assert.ok(called);
+  assert.strictEqual(res.statusCode, 200);
+});
+
+test('authorize denies action when role lacks permission', () => {
+  const req = { headers: { 'x-role': 'recruiter' } };
+  const res = makeRes();
+  authorize('delete', () => { throw new Error('should not call'); })(req, res);
+  assert.strictEqual(res.statusCode, 403);
+  assert.ok(res.ended);
+});

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,0 +1,40 @@
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const { server } = require('../src/server');
+
+let port;
+
+before((t, done) => {
+  server.listen(0, () => {
+    port = server.address().port;
+    done();
+  });
+});
+
+after((t, done) => {
+  server.close(done);
+});
+
+test('admin can create candidate', async () => {
+  const res = await fetch(`http://localhost:${port}/candidates`, {
+    method: 'POST',
+    headers: { 'x-role': 'admin' }
+  });
+  assert.strictEqual(res.status, 201);
+});
+
+test('manager cannot create candidate', async () => {
+  const res = await fetch(`http://localhost:${port}/candidates`, {
+    method: 'POST',
+    headers: { 'x-role': 'manager' }
+  });
+  assert.strictEqual(res.status, 403);
+});
+
+test('recruiter can read candidates', async () => {
+  const res = await fetch(`http://localhost:${port}/candidates`, {
+    method: 'GET',
+    headers: { 'x-role': 'recruiter' }
+  });
+  assert.strictEqual(res.status, 200);
+});


### PR DESCRIPTION
## Summary
- define admin, manager, recruiter roles
- add authorization middleware and sample candidate endpoints
- add unit and integration tests for permission separation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893524865d4832fafc02343ccf95934