### PR TITLE
Expose user HTTP routes and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ El servidor se ejecutará en `http://localhost:8000`.
 - `PUT /candidates/{id}` – actualizar candidato
 - `DELETE /candidates/{id}` – eliminar candidato
 
-Recursos análogos existen para `comments`, `evaluations` y `activities`. Además se han añadido tablas `users` y `files` disponibles mediante los servicios internos.
+Endpoints equivalentes existen para `comments`, `evaluations`, `activities` y `users`.
+
+- `GET /users` – lista de usuarios
+- `POST /users` – crear usuario
+- `GET /users/{id}` – obtener usuario
+- `PUT /users/{id}` – actualizar usuario
+- `DELETE /users/{id}` – eliminar usuario
+
+Los endpoints de `files` siguen disponibles y requieren autenticación.
 
 ### Documentación
 La documentación OpenAPI está disponible en [`/swagger.json`](http://localhost:8000/swagger.json).

--- a/app.py
+++ b/app.py
@@ -115,6 +115,19 @@ class RequestHandler(BaseHTTPRequestHandler):
                 send_json(self, {'error': 'Not found'}, 404)
             return
 
+        if self.path == '/users':
+            send_json(self, services.get_users())
+            return
+        m = re.fullmatch(r'/users/(\d+)', self.path)
+        if m:
+            uid = int(m.group(1))
+            user = services.get_user(uid)
+            if user:
+                send_json(self, user)
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
+
         if self.path == '/files':
             if not is_authorized(self):
                 return
@@ -218,6 +231,10 @@ class RequestHandler(BaseHTTPRequestHandler):
             aid = services.create_activity(data)
             send_json(self, {'id': aid}, 201)
             return
+        if self.path == '/users':
+            uid = services.create_user(data)
+            send_json(self, {'id': uid}, 201)
+            return
         send_json(self, {'error': 'Unsupported endpoint'}, 404)
 
     def do_PUT(self):
@@ -258,6 +275,15 @@ class RequestHandler(BaseHTTPRequestHandler):
             else:
                 send_json(self, {'error': 'Not found'}, 404)
             return
+        m = re.fullmatch(r'/users/(\d+)', self.path)
+        if m:
+            uid = int(m.group(1))
+            ok = services.update_user(uid, data)
+            if ok:
+                send_json(self, {'status': 'updated'})
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
         send_json(self, {'error': 'Unsupported endpoint'}, 404)
 
     def do_DELETE(self):
@@ -292,6 +318,15 @@ class RequestHandler(BaseHTTPRequestHandler):
         if m:
             aid = int(m.group(1))
             ok = services.delete_activity(aid)
+            if ok:
+                send_json(self, {'status': 'deleted'})
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
+        m = re.fullmatch(r'/users/(\d+)', self.path)
+        if m:
+            uid = int(m.group(1))
+            ok = services.delete_user(uid)
             if ok:
                 send_json(self, {'status': 'deleted'})
             else:

--- a/swagger.json
+++ b/swagger.json
@@ -93,6 +93,15 @@
       "put": {"summary": "Update activity", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Updated"}, "404": {"description": "Not found"}}},
       "delete": {"summary": "Delete activity", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Deleted"}, "404": {"description": "Not found"}}}
     },
+    "/users": {
+      "get": {"summary": "List users", "responses": {"200": {"description": "OK"}}},
+      "post": {"summary": "Create user", "responses": {"201": {"description": "Created"}}}
+    },
+    "/users/{id}": {
+      "get": {"summary": "Get user", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "OK"}, "404": {"description": "Not found"}}},
+      "put": {"summary": "Update user", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Updated"}, "404": {"description": "Not found"}}},
+      "delete": {"summary": "Delete user", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Deleted"}, "404": {"description": "Not found"}}}
+    },
     "/files": {
       "get": {"summary": "List files", "responses": {"200": {"description": "OK"}}},
       "post": {
@@ -168,6 +177,14 @@
           "filename": {"type": "string"},
           "path": {"type": "string"},
           "uploaded_at": {"type": "string"}
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "integer"},
+          "username": {"type": "string"},
+          "email": {"type": "string"}
         }
       }
     }


### PR DESCRIPTION
## Summary
- add CRUD HTTP endpoints for users
- document user routes in README and swagger spec

## Testing
- `python -m py_compile app.py services.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68936fd36af0832fb4622b265584c4c2