### PR TITLE
Expose user HTTP routes and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ El servidor se ejecutará en `http://localhost:8000`.
 - `PUT /candidates/{id}` – actualizar candidato
 - `DELETE /candidates/{id}` – eliminar candidato
 
-Recursos análogos existen para `comments`, `evaluations` y `activities`. Además se han añadido tablas `users` y `files` disponibles mediante los servicios internos.
+Endpoints equivalentes existen para `comments`, `evaluations`, `activities` y `users`.
+
+- `GET /users` – lista de usuarios
+- `POST /users` – crear usuario
+- `GET /users/{id}` – obtener usuario
+- `PUT /users/{id}` – actualizar usuario
+- `DELETE /users/{id}` – eliminar usuario
+
+Los endpoints de `files` siguen disponibles y requieren autenticación.
 
 ### Documentación
 La documentación OpenAPI está disponible en [`/swagger.json`](http://localhost:8000/swagger.json).

--- a/app.py
+++ b/app.py
@@ -115,6 +115,19 @@ class RequestHandler(BaseHTTPRequestHandler):
                 send_json(self, {'error': 'Not found'}, 404)
             return
 
+        if self.path == '/users':
+            send_json(self, services.get_users())
+            return
+        m = re.fullmatch(r'/users/(\d+)', self.path)
+        if m:
+            uid = int(m.group(1))
+            user = services.get_user(uid)
+            if user:
+                send_json(self, user)
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
+
         if self.path == '/files':
             if not is_authorized(self):
                 return
@@ -218,6 +231,10 @@ class RequestHandler(BaseHTTPRequestHandler):
             aid = services.create_activity(data)
             send_json(self, {'id': aid}, 201)
             return
+        if self.path == '/users':
+            uid = services.create_user(data)
+            send_json(self, {'id': uid}, 201)
+            return
         send_json(self, {'error': 'Unsupported endpoint'}, 404)
 
     def do_PUT(self):
@@ -258,6 +275,15 @@ class RequestHandler(BaseHTTPRequestHandler):
             else:
                 send_json(self, {'error': 'Not found'}, 404)
             return
+        m = re.fullmatch(r'/users/(\d+)', self.path)
+        if m:
+            uid = int(m.group(1))
+            ok = services.update_user(uid, data)
+            if ok:
+                send_json(self, {'status': 'updated'})
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
         send_json(self, {'error': 'Unsupported endpoint'}, 404)
 
     def do_DELETE(self):
@@ -292,6 +318,15 @@ class RequestHandler(BaseHTTPRequestHandler):
         if m:
             aid = int(m.group(1))
             ok = services.delete_activity(aid)
+            if ok:
+                send_json(self, {'status': 'deleted'})
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
+        m = re.fullmatch(r'/users/(\d+)', self.path)
+        if m:
+            uid = int(m.group(1))
+            ok = services.delete_user(uid)
             if ok:
                 send_json(self, {'status': 'deleted'})
             else:

--- a/swagger.json
+++ b/swagger.json
@@ -93,6 +93,15 @@
       "put": {"summary": "Update activity", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Updated"}, "404": {"description": "Not found"}}},
       "delete": {"summary": "Delete activity", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Deleted"}, "404": {"description": "Not found"}}}
     },
+    "/users": {
+      "get": {"summary": "List users", "responses": {"200": {"description": "OK"}}},
+      "post": {"summary": "Create user", "responses": {"201": {"description": "Created"}}}
+    },
+    "/users/{id}": {
+      "get": {"summary": "Get user", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "OK"}, "404": {"description": "Not found"}}},
+      "put": {"summary": "Update user", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Updated"}, "404": {"description": "Not found"}}},
+      "delete": {"summary": "Delete user", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Deleted"}, "404": {"description": "Not found"}}}
+    },
     "/files": {
       "get": {"summary": "List files", "responses": {"200": {"description": "OK"}}},
       "post": {
@@ -168,6 +177,14 @@
           "filename": {"type": "string"},
           "path": {"type": "string"},
           "uploaded_at": {"type": "string"}
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "integer"},
+          "username": {"type": "string"},
+          "email": {"type": "string"}
         }
       }
     }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,109 @@
+import os
+import json
+import tempfile
+import threading
+import shutil
+from http.server import HTTPServer
+import http.client
+import sys
+from pathlib import Path
+
+import pytest
+
+# Set up isolated database and upload directory before importing app
+# Ensure project root on path and configure isolated env
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+_db_fd, _db_path = tempfile.mkstemp()
+os.close(_db_fd)
+os.environ['DB_NAME'] = _db_path
+_upload_dir = tempfile.mkdtemp()
+os.environ['UPLOAD_DIR'] = _upload_dir
+
+import db
+from app import RequestHandler, ensure_upload_dir
+
+
+def _request(port, method, path, body=None):
+    conn = http.client.HTTPConnection('localhost', port)
+    headers = {}
+    data = None
+    if body is not None:
+        headers['Content-Type'] = 'application/json'
+        data = json.dumps(body)
+    conn.request(method, path, body=data, headers=headers)
+    resp = conn.getresponse()
+    raw = resp.read()
+    conn.close()
+    if raw:
+        payload = json.loads(raw.decode())
+    else:
+        payload = None
+    return resp.status, payload
+
+
+@pytest.fixture(scope='module')
+def server():
+    db.init_db()
+    ensure_upload_dir()
+    httpd = HTTPServer(('localhost', 0), RequestHandler)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    yield port
+    httpd.shutdown()
+    thread.join()
+    os.remove(_db_path)
+    shutil.rmtree(_upload_dir)
+
+
+def test_candidate_crud(server):
+    port = server
+    status, data = _request(port, 'POST', '/candidates', {'name': 'Alice', 'email': 'alice@example.com'})
+    assert status == 201
+    cid = data['id']
+
+    status, data = _request(port, 'GET', '/candidates')
+    assert status == 200
+    assert any(c['id'] == cid for c in data)
+
+    status, data = _request(port, 'GET', f'/candidates/{cid}')
+    assert status == 200
+    assert data['name'] == 'Alice'
+
+    status, data = _request(port, 'PUT', f'/candidates/{cid}', {'name': 'Alice Smith', 'email': 'alice.smith@example.com'})
+    assert status == 200
+    assert data['status'] == 'updated'
+
+    status, data = _request(port, 'DELETE', f'/candidates/{cid}')
+    assert status == 200
+    assert data['status'] == 'deleted'
+
+    status, _ = _request(port, 'GET', f'/candidates/{cid}')
+    assert status == 404
+
+
+def test_user_crud(server):
+    port = server
+    status, data = _request(port, 'POST', '/users', {'username': 'bob', 'email': 'bob@example.com'})
+    assert status == 201
+    uid = data['id']
+
+    status, data = _request(port, 'GET', '/users')
+    assert status == 200
+    assert any(u['id'] == uid for u in data)
+
+    status, data = _request(port, 'GET', f'/users/{uid}')
+    assert status == 200
+    assert data['username'] == 'bob'
+
+    status, data = _request(port, 'PUT', f'/users/{uid}', {'username': 'bobby', 'email': 'bob@example.com'})
+    assert status == 200
+    assert data['status'] == 'updated'
+
+    status, data = _request(port, 'DELETE', f'/users/{uid}')
+    assert status == 200
+    assert data['status'] == 'deleted'
+
+    status, _ = _request(port, 'GET', f'/users/{uid}')
+    assert status == 404


### PR DESCRIPTION
## Summary
- add CRUD HTTP endpoints for users
- document user routes in README and swagger spec
- add pytest integration tests for candidate and user endpoints

## Testing
- `python -m py_compile app.py services.py tests/test_api.py`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68936fd36af0832fb4622b265584c4c2