### PR TITLE
Expose user HTTP routes and add lightweight frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ El servidor se ejecutará en `http://localhost:8000`.
 - `PUT /candidates/{id}` – actualizar candidato
 - `DELETE /candidates/{id}` – eliminar candidato
 
-Recursos análogos existen para `comments`, `evaluations` y `activities`. Además se han añadido tablas `users` y `files` disponibles mediante los servicios internos.
+Endpoints equivalentes existen para `comments`, `evaluations`, `activities` y `users`.
+
+- `GET /users` – lista de usuarios
+- `POST /users` – crear usuario
+- `GET /users/{id}` – obtener usuario
+- `PUT /users/{id}` – actualizar usuario
+- `DELETE /users/{id}` – eliminar usuario
+
+Los endpoints de `files` siguen disponibles y requieren autenticación.
 
 ### Documentación
 La documentación OpenAPI está disponible en [`/swagger.json`](http://localhost:8000/swagger.json).
@@ -46,3 +54,16 @@ El proyecto incluye un servicio de subida y descarga de archivos con las siguien
 2. Envíe una petición `POST /files` con autenticación y un archivo multipart para subirlo. Use `GET /files/{id}` para descargarlo.
 
 Los archivos se guardan dentro de `uploads` con permisos restringidos.
+
+## Frontend ligero
+
+En el directorio `frontend/` se incluye una interfaz web sencilla para gestionar usuarios.
+Los archivos son estáticos (`index.html`, `app.js` y `style.css`) y consumen la API directamente.
+
+Para probarla, sirve el directorio con cualquier servidor estático, por ejemplo:
+
+```bash
+python -m http.server --directory frontend 3000
+```
+
+Con la API ejecutándose en `http://localhost:8000`, abre `http://localhost:3000` en el navegador.

--- a/app.py
+++ b/app.py
@@ -115,6 +115,19 @@ class RequestHandler(BaseHTTPRequestHandler):
                 send_json(self, {'error': 'Not found'}, 404)
             return
 
+        if self.path == '/users':
+            send_json(self, services.get_users())
+            return
+        m = re.fullmatch(r'/users/(\d+)', self.path)
+        if m:
+            uid = int(m.group(1))
+            user = services.get_user(uid)
+            if user:
+                send_json(self, user)
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
+
         if self.path == '/files':
             if not is_authorized(self):
                 return
@@ -218,6 +231,10 @@ class RequestHandler(BaseHTTPRequestHandler):
             aid = services.create_activity(data)
             send_json(self, {'id': aid}, 201)
             return
+        if self.path == '/users':
+            uid = services.create_user(data)
+            send_json(self, {'id': uid}, 201)
+            return
         send_json(self, {'error': 'Unsupported endpoint'}, 404)
 
     def do_PUT(self):
@@ -258,6 +275,15 @@ class RequestHandler(BaseHTTPRequestHandler):
             else:
                 send_json(self, {'error': 'Not found'}, 404)
             return
+        m = re.fullmatch(r'/users/(\d+)', self.path)
+        if m:
+            uid = int(m.group(1))
+            ok = services.update_user(uid, data)
+            if ok:
+                send_json(self, {'status': 'updated'})
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
         send_json(self, {'error': 'Unsupported endpoint'}, 404)
 
     def do_DELETE(self):
@@ -292,6 +318,15 @@ class RequestHandler(BaseHTTPRequestHandler):
         if m:
             aid = int(m.group(1))
             ok = services.delete_activity(aid)
+            if ok:
+                send_json(self, {'status': 'deleted'})
+            else:
+                send_json(self, {'error': 'Not found'}, 404)
+            return
+        m = re.fullmatch(r'/users/(\d+)', self.path)
+        if m:
+            uid = int(m.group(1))
+            ok = services.delete_user(uid)
             if ok:
                 send_json(self, {'status': 'deleted'})
             else:

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,74 @@
+const API_BASE = '';
+
+async function fetchUsers() {
+  const res = await fetch(`${API_BASE}/users`);
+  if (!res.ok) throw new Error('Failed to load users');
+  return res.json();
+}
+
+function renderUsers(users) {
+  const tbody = document.getElementById('users-body');
+  tbody.innerHTML = '';
+  users.forEach(u => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${u.name}</td><td>${u.email}</td><td><button data-id="${u.id}" class="delete">Delete</button></td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+async function loadUsers() {
+  try {
+    const users = await fetchUsers();
+    renderUsers(users);
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+async function addUser(data) {
+  const res = await fetch(`${API_BASE}/users`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  if (!res.ok) throw new Error('Failed to add user');
+  return res.json();
+}
+
+async function deleteUser(id) {
+  const res = await fetch(`${API_BASE}/users/${id}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error('Failed to delete user');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadUsers();
+
+  document.getElementById('user-form').addEventListener('submit', async e => {
+    e.preventDefault();
+    const form = e.target;
+    const data = {
+      name: form.name.value.trim(),
+      email: form.email.value.trim()
+    };
+    if (!data.name || !data.email) return;
+    try {
+      await addUser(data);
+      form.reset();
+      loadUsers();
+    } catch (err) {
+      console.error(err);
+    }
+  });
+
+  document.getElementById('users-table').addEventListener('click', async e => {
+    if (e.target.matches('button.delete')) {
+      const id = e.target.dataset.id;
+      try {
+        await deleteUser(id);
+        loadUsers();
+      } catch (err) {
+        console.error(err);
+      }
+    }
+  });
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Candidate Manager</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="container">
+    <h1>Candidate Manager</h1>
+    <section aria-labelledby="users-heading">
+      <h2 id="users-heading">Users</h2>
+      <table id="users-table">
+        <thead>
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col">Email</th>
+            <th scope="col">Actions</th>
+          </tr>
+        </thead>
+        <tbody id="users-body"></tbody>
+      </table>
+    </section>
+    <section aria-labelledby="add-user-heading">
+      <h2 id="add-user-heading">Add User</h2>
+      <form id="user-form">
+        <label>
+          Name
+          <input type="text" name="name" required />
+        </label>
+        <label>
+          Email
+          <input type="email" name="email" required />
+        </label>
+        <button type="submit">Add</button>
+      </form>
+    </section>
+  </main>
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,72 @@
+:root {
+  --primary: #2563eb;
+  --background: #f9fafb;
+  --text: #1f2937;
+  --font-stack: system-ui, sans-serif;
+}
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  font-family: var(--font-stack);
+  background: var(--background);
+  color: var(--text);
+}
+.container {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+h1, h2 {
+  font-weight: 600;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+th, td {
+  padding: 0.5rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+input {
+  padding: 0.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+}
+button {
+  align-self: flex-start;
+  padding: 0.5rem 1rem;
+  border: none;
+  background: var(--primary);
+  color: white;
+  border-radius: 4px;
+  cursor: pointer;
+}
+button:hover {
+  opacity: 0.9;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #1f2937;
+    --text: #f9fafb;
+  }
+  body {
+    background: var(--background);
+    color: var(--text);
+  }
+  th, td {
+    border-color: #374151;
+  }
+  input {
+    background: #374151;
+    border-color: #4b5563;
+    color: var(--text);
+  }
+}

--- a/swagger.json
+++ b/swagger.json
@@ -93,6 +93,15 @@
       "put": {"summary": "Update activity", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Updated"}, "404": {"description": "Not found"}}},
       "delete": {"summary": "Delete activity", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Deleted"}, "404": {"description": "Not found"}}}
     },
+    "/users": {
+      "get": {"summary": "List users", "responses": {"200": {"description": "OK"}}},
+      "post": {"summary": "Create user", "responses": {"201": {"description": "Created"}}}
+    },
+    "/users/{id}": {
+      "get": {"summary": "Get user", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "OK"}, "404": {"description": "Not found"}}},
+      "put": {"summary": "Update user", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Updated"}, "404": {"description": "Not found"}}},
+      "delete": {"summary": "Delete user", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}], "responses": {"200": {"description": "Deleted"}, "404": {"description": "Not found"}}}
+    },
     "/files": {
       "get": {"summary": "List files", "responses": {"200": {"description": "OK"}}},
       "post": {
@@ -168,6 +177,14 @@
           "filename": {"type": "string"},
           "path": {"type": "string"},
           "uploaded_at": {"type": "string"}
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "integer"},
+          "username": {"type": "string"},
+          "email": {"type": "string"}
         }
       }
     }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,109 @@
+import os
+import json
+import tempfile
+import threading
+import shutil
+from http.server import HTTPServer
+import http.client
+import sys
+from pathlib import Path
+
+import pytest
+
+# Set up isolated database and upload directory before importing app
+# Ensure project root on path and configure isolated env
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+_db_fd, _db_path = tempfile.mkstemp()
+os.close(_db_fd)
+os.environ['DB_NAME'] = _db_path
+_upload_dir = tempfile.mkdtemp()
+os.environ['UPLOAD_DIR'] = _upload_dir
+
+import db
+from app import RequestHandler, ensure_upload_dir
+
+
+def _request(port, method, path, body=None):
+    conn = http.client.HTTPConnection('localhost', port)
+    headers = {}
+    data = None
+    if body is not None:
+        headers['Content-Type'] = 'application/json'
+        data = json.dumps(body)
+    conn.request(method, path, body=data, headers=headers)
+    resp = conn.getresponse()
+    raw = resp.read()
+    conn.close()
+    if raw:
+        payload = json.loads(raw.decode())
+    else:
+        payload = None
+    return resp.status, payload
+
+
+@pytest.fixture(scope='module')
+def server():
+    db.init_db()
+    ensure_upload_dir()
+    httpd = HTTPServer(('localhost', 0), RequestHandler)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    yield port
+    httpd.shutdown()
+    thread.join()
+    os.remove(_db_path)
+    shutil.rmtree(_upload_dir)
+
+
+def test_candidate_crud(server):
+    port = server
+    status, data = _request(port, 'POST', '/candidates', {'name': 'Alice', 'email': 'alice@example.com'})
+    assert status == 201
+    cid = data['id']
+
+    status, data = _request(port, 'GET', '/candidates')
+    assert status == 200
+    assert any(c['id'] == cid for c in data)
+
+    status, data = _request(port, 'GET', f'/candidates/{cid}')
+    assert status == 200
+    assert data['name'] == 'Alice'
+
+    status, data = _request(port, 'PUT', f'/candidates/{cid}', {'name': 'Alice Smith', 'email': 'alice.smith@example.com'})
+    assert status == 200
+    assert data['status'] == 'updated'
+
+    status, data = _request(port, 'DELETE', f'/candidates/{cid}')
+    assert status == 200
+    assert data['status'] == 'deleted'
+
+    status, _ = _request(port, 'GET', f'/candidates/{cid}')
+    assert status == 404
+
+
+def test_user_crud(server):
+    port = server
+    status, data = _request(port, 'POST', '/users', {'username': 'bob', 'email': 'bob@example.com'})
+    assert status == 201
+    uid = data['id']
+
+    status, data = _request(port, 'GET', '/users')
+    assert status == 200
+    assert any(u['id'] == uid for u in data)
+
+    status, data = _request(port, 'GET', f'/users/{uid}')
+    assert status == 200
+    assert data['username'] == 'bob'
+
+    status, data = _request(port, 'PUT', f'/users/{uid}', {'username': 'bobby', 'email': 'bob@example.com'})
+    assert status == 200
+    assert data['status'] == 'updated'
+
+    status, data = _request(port, 'DELETE', f'/users/{uid}')
+    assert status == 200
+    assert data['status'] == 'deleted'
+
+    status, _ = _request(port, 'GET', f'/users/{uid}')
+    assert status == 404


### PR DESCRIPTION
## Summary
- add CRUD HTTP endpoints and docs for users
- provide pytest coverage for candidate and user endpoints
- introduce a lightweight static frontend to manage users, with responsive styling and API integration

## Testing
- `python -m py_compile app.py services.py tests/test_api.py`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68936fd36af0832fb4622b265584c4c2