### PR TITLE
Add CORS support for backend API

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,9 +34,16 @@ def parse_body(handler):
     return {}
 
 
+def add_cors_headers(handler):
+    handler.send_header('Access-Control-Allow-Origin', '*')
+    handler.send_header('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+    handler.send_header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
+
+
 def send_json(handler, data, status=200):
     handler.send_response(status)
     handler.send_header('Content-Type', 'application/json')
+    add_cors_headers(handler)
     handler.end_headers()
     handler.wfile.write(json.dumps(data).encode())
 
@@ -67,6 +74,11 @@ def is_logged_in(handler):
 
 
 class RequestHandler(BaseHTTPRequestHandler):
+    def do_OPTIONS(self):
+        self.send_response(204)
+        add_cors_headers(self)
+        self.end_headers()
+
     def do_GET(self):
         if self.path == '/swagger.json':
             try:
@@ -176,6 +188,7 @@ class RequestHandler(BaseHTTPRequestHandler):
             self.send_header('Content-Type', mime)
             self.send_header('Content-Length', str(len(data)))
             self.send_header('Content-Disposition', f'attachment; filename="{f["filename"]}"')
+            add_cors_headers(self)
             self.end_headers()
             self.wfile.write(data)
             return

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,4 +1,4 @@
-const API_BASE = '';
+const API_BASE = 'http://localhost:8000';
 const token = localStorage.getItem('token');
 if (!token) {
   window.location.href = 'login.html';

--- a/frontend/login.js
+++ b/frontend/login.js
@@ -1,4 +1,4 @@
-const API_BASE = '';
+const API_BASE = 'http://localhost:8000';
 
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('login-form');


### PR DESCRIPTION
## Summary
- allow cross-origin frontend requests by adding CORS headers to backend responses
- handle browser preflight with an OPTIONS endpoint and CORS-aware file downloads

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a5f2f1e10832f898edf78ef9969f4